### PR TITLE
feat: use existing servers & define default servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,9 +296,12 @@ require('lsp-setup').setup({
     end,
     -- Global capabilities
     capabilities = vim.lsp.protocol.make_client_capabilities(),
-    -- Configuration of LSP servers 
+    -- Install LSP servers automatically (requires mason and mason-lspconfig)
+    ensure_installed = {
+        "lua_ls"
+    },
+    -- Configuration of LSP servers
     servers = {
-        -- Install LSP servers automatically (requires mason and mason-lspconfig)
         -- LSP server configuration please see: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md
         -- pylsp = {},
         -- rust_analyzer = {


### PR DESCRIPTION
this commit enables the use of pre-installed LSP servers. It requires that the auto-install logic is broken out into ensure_installed in order to keep auto install functionality while allowing for servers to be set up in a unified manner.

  - change vim.tbl_deep_extend order to ensure opts overrides defaults
  - use ensure_installed table to define ensure_installed for mason_lspconfig
  - add set up for any servers not managed by mason
  - minor formatting (add missing commas)
  - include setup instructions in README